### PR TITLE
Fixing Theme Export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './themes.css';
+
 export { default as Button } from './Button/Button';
 export type { ButtonProps } from './Button/Button';
 


### PR DESCRIPTION
Simple import to allow existing themes to be easily accessible, so users don't have to redefine themes provided by the package.